### PR TITLE
Simplify `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,8 @@ os:
 env:
   global:
     - secure: q+azCWiZLMnpauOWB885uoQV0NPhFs9tNX1p0omMAV6mJoC8JD5F7zbTrC3Q+Tz1V97kpokCMTHkqOK8Nb7Z6D8aPqpMHZn/BLE07k0YmbwLyIUXF1HXm5JLeG2W3e2GNy2NRU2moZoO7vNRBL9Rz3UjkAOinTZQ6oXWJcZDEEA=
-install:
-  - rustc -v
-before_script:
-    - rustc -v
-    - cargo -V
-script:
-    - cargo build -v
-    - cargo test -v
-    - cargo doc -v
 after_script:
+  - cargo doc -v
   - curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh
 notifications:
   email:


### PR DESCRIPTION
Travis [already prints](https://travis-ci.org/andelf/rust-iconv/builds/39691496#L21) the versions of `rustc` and `cargo` right after it installs them. Also, the [default test script](http://docs.travis-ci.com/user/languages/rust/#Default-test-script) already runs verbose `cargo build` and `cargo test`, so really all that's needed here is to ensure that `cargo doc` is executed after the script (`after_script`).
